### PR TITLE
Release - 3.1.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.1.60 (Jun 1, 2026)
+### Improvements
+- Fixed a WebSocket client callback queue hang by decoupling client callbacks and notifications onto dedicated serial queues
+- Added a callback generation guard so stale callbacks are dropped after `clear` and connection teardown
+- Added regression test coverage for `SBDWebSocketClient` callback queue lifecycle
+
 ## 3.1.59 (May 7, 2026)
 ### **Improvements**
 - Fixed a WebSocket client teardown race that could crash on `disconnect`/`clear` re-entry and stale engine callbacks

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
 
-// swift-tools-version:5.3
+// swift-tools-version:5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,5 @@
 
-// swift-tools-version:5.10
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 import PackageDescription
 let package = Package(
@@ -15,8 +15,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SendBirdSDK",
-            url: "https://github.com/sendbird/sendbird-ios-framework/releases/download/v3.1.59/SendBirdSDK.xcframework.zip",
-            checksum: "c79e4f3ec3a21ef08d2e51796a04e21f76e8c797970a32acc2035739bb7b127e"
+            url: "https://github.com/sendbird/sendbird-ios-framework/releases/download/v3.1.60/SendBirdSDK.xcframework.zip",
+            checksum: "8852637f660ef2703450c56a966fb94a40453139553218d1543af8fe9617df33"
         ),
     ]
 )


### PR DESCRIPTION
Release 3.1.60 (SPM distribution).

- Update `Package.swift` binaryTarget → `v3.1.60` release asset + checksum
- Update CHANGELOG

binaryTarget:
- url: `sendbird-ios-framework/releases/download/v3.1.60/SendBirdSDK.xcframework.zip`
- checksum: `8852637f660ef2703450c56a966fb94a40453139553218d1543af8fe9617df33`

Source: messaging-ios [3.1.60](https://github.com/sendbird/messaging-ios/releases/tag/3.1.60)

> Depends on sendbird-ios-framework#83 release `v3.1.60` asset being published first (else SPM resolution 404s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)